### PR TITLE
chore: configure renovate for helm chart upgrade

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,6 +9,19 @@
   "schedule": "* 0-10 * * 1",
   "timezone": "Europe/Paris",
   "enabledManagers": [
+    "custom.regex",
     "github-actions"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "bin\\/do$"
+      ],
+      "matchStrings": [
+        "#\\s*renovate-helm: depName=(?<depName>.*?)( registryUrl=(?<registryUrl>.*?))?\\s.*?_version\\s*=\\s*(?<currentValue>.*)"
+      ],
+      "datasourceTemplate": "helm"
+    }
   ]
 }

--- a/bin/do
+++ b/bin/do
@@ -34,8 +34,9 @@ fi
 doctl kubernetes cluster kubeconfig save "$cluster_name"
 
 echo "Install ArgoCD"
-argocd_version=7.7.11
 helm repo add argo https://argoproj.github.io/argo-helm
+# renovate-helm: depName=argocd registryUrl=https://argoproj.github.io/argo-helm
+argocd_version=7.7.11
 helm upgrade \
   --install argocd argo/argo-cd \
   --namespace "argocd" \


### PR DESCRIPTION
This pull request includes a change to the `.github/renovate.json` file to add custom regex management for Renovate. The most important change is the addition of a custom manager to handle dependencies specified in a specific format within the `bin/do` file.

Changes to Renovate configuration:

* `.github/renovate.json`: Added `custom.regex` to `enabledManagers` and defined a `customManager` to match and manage dependencies using regex patterns in the `bin/do` file.