### PR TITLE
feat: install NATS

### DIFF
--- a/bin/do
+++ b/bin/do
@@ -99,6 +99,17 @@ while true; do
   sleep 5
 done
 
+echo "Install NATS server"
+helm repo add nats https://nats-io.github.io/k8s/helm/charts/
+nats_version=1.2.8
+helm upgrade \
+  --install nats nats/nats \
+  --namespace nats \
+  --version $nats_version \
+  --create-namespace \
+  --values k8s/nats/helm/affinity.yml \
+  --wait
+
 echo "Change ArgoCD url"
 kubectl -n argocd patch cm argocd-cm -p '{"data": {"url": "https://argocd.tracker-tv.com"}}'
 kubectl rollout -n argocd restart deploy argocd-server

--- a/k8s/nats/helm/affinity.yml
+++ b/k8s/nats/helm/affinity.yml
@@ -1,0 +1,13 @@
+global:
+  spec:
+    template:
+      spec:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: beta.kubernetes.io/instance-type
+                      operator: In
+                      values:
+                        - s-2vcpu-4gb


### PR DESCRIPTION
This pull request includes a significant change to the Kubernetes configuration for NATS. The change introduces a node affinity configuration to ensure that the NATS pods are scheduled on specific types of nodes.

Kubernetes configuration updates:

* `k8s/nats/helm/affinity.yml`: Added node affinity rules to ensure NATS pods are scheduled on nodes with the instance type `s-2vcpu-4gb`.